### PR TITLE
PM: Modify to handle failure to change state

### DIFF
--- a/os/arch/arm/src/amebasmart/amebasmart_serial.c
+++ b/os/arch/arm/src/amebasmart/amebasmart_serial.c
@@ -1285,11 +1285,11 @@ static int amebasmart_serial_pmprepare(FAR struct pm_callback_s *cb, int domain,
 			}
 #endif
 #ifdef CONFIG_RTL8730E_UART4
-			// LOGUART_TypeDef *UARTLOG = LOGUART_DEV;
-			// if (!(UARTLOG->LOGUART_UART_LSR & LOG_UART_IDX_FLAG[2].empty)) {		/* log UART Tx Empty Check */
-			// 	printf("\n[%s] - %d, UARTLOG->LOGUART_UART_LSR = %d, LOG_UART_IDX_FLAG[2].empty = %d\n",__FUNCTION__,__LINE__, UARTLOG->LOGUART_UART_LSR, LOG_UART_IDX_FLAG[2].empty);
-			// 	return ERROR;
-			// }
+			LOGUART_TypeDef *UARTLOG = LOGUART_DEV;
+			if (!(UARTLOG->LOGUART_UART_LSR & LOG_UART_IDX_FLAG[2].empty)) {		/* log UART Tx Empty Check */
+				printf("\n[%s] - %d, UARTLOG->LOGUART_UART_LSR = %d, LOG_UART_IDX_FLAG[2].empty = %d\n",__FUNCTION__,__LINE__, UARTLOG->LOGUART_UART_LSR, LOG_UART_IDX_FLAG[2].empty);
+				return ERROR;
+			}
 #endif
 			break;
 		default:


### PR DESCRIPTION
-If pm driver preparation fails, revert the preparation back to current state for all drivers.
-Initiate wdog timer for pre-set delay to induce delay before next attempt to change to lower power state.

@edwakuwaku this should resolve the infinite loop without delay issue when state change is rejected.
Please take a look and we can discuss thereafter.